### PR TITLE
20.02.xWindows 10 App Essentials 20.02

### DIFF
--- a/addon/appModules/calculator.py
+++ b/addon/appModules/calculator.py
@@ -100,6 +100,3 @@ class AppModule(appModuleHandler.AppModule):
 				if isinstance(resultsScreen, UIA) and resultsScreen.UIAElement.cachedClassName == "LandmarkTarget":
 					# And no, do not allow focus to move.
 					queueHandler.queueFunction(queueHandler.eventQueue, resultsScreen.firstChild.reportFocus)
-
-	# Without this, gesture binding fails even with script decorator deployed.
-	__gestures = {}

--- a/addon/appModules/calculator.py
+++ b/addon/appModules/calculator.py
@@ -1,6 +1,6 @@
 # appModules/calculator.py
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2015-2019 NV Access Limited, Joseph Lee
+# Copyright (C) 2015-2020 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/addon/appModules/cortana.py
+++ b/addon/appModules/cortana.py
@@ -1,6 +1,6 @@
 # Cortana Conversations (beta)
 # Part of Windows 10 App Essentials collection
-# Copyright 2019 Joseph Lee, released under GPL
+# Copyright 2019-2020 Joseph Lee, released under GPL
 
 # Various workarounds for Cortana Conversations (beta in build 18922 and later)
 

--- a/addon/appModules/hxcalendarappimm.py
+++ b/addon/appModules/hxcalendarappimm.py
@@ -1,6 +1,6 @@
 # WinTenApps/hxcalendarappimm.py
 # Part of Windows 10 App Essentials collection
-# Copyright 2016-2019 Joseph Lee, released under GPL.
+# Copyright 2016-2020 Joseph Lee, released under GPL.
 
 # Fixes for certain issues with Windows 10 Calendar app (based on Outlook 2016).
 

--- a/addon/appModules/maps.py
+++ b/addon/appModules/maps.py
@@ -1,6 +1,6 @@
 # WinTenApps/maps.py
 # Part of Windows 10 App Essentials collection
-# Copyright 2016-2019 Joseph Lee, released under GPL.
+# Copyright 2016-2020 Joseph Lee, released under GPL.
 
 # Numerous enhancements for Bing Maps app.
 

--- a/addon/appModules/microsoft_msn_weather.py
+++ b/addon/appModules/microsoft_msn_weather.py
@@ -1,6 +1,6 @@
 # WinTenApps/microsoft_msn_weather.py
 # Part of Windows 10 App Essentials collection
-# Copyright 2016 Derek Riemer, released under GPL.
+# Copyright 2016-2020 Derek Riemer, released under GPL.
 
 # Provides workarounds for the weather app.
 

--- a/addon/appModules/peopleapp.py
+++ b/addon/appModules/peopleapp.py
@@ -1,6 +1,6 @@
 # WinTenApps/peopleapp.py
 # Part of Windows 10 App Essentials collection
-# Copyright 2018-2019 Joseph Lee, released under GPL.
+# Copyright 2018-2020 Joseph Lee, released under GPL.
 
 # Various workarounds for People app (modern version of Outlook Contacts).
 

--- a/addon/appModules/searchui.py
+++ b/addon/appModules/searchui.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Extended by Joseph Lee (copyright 2016-2019, released under GPL)
+# Extended by Joseph Lee (copyright 2016-2020, released under GPL)
 
 # Extended to let NVDA cooperate with Cortana.
 

--- a/addon/appModules/systemsettingsadminflows.py
+++ b/addon/appModules/systemsettingsadminflows.py
@@ -1,6 +1,6 @@
 # Windows 10 Settings/Reset This PC
 # Part of Windows 10 App Essentials collection
-# Copyright 2018-2019 Joseph Lee, released under GPL
+# Copyright 2018-2020 Joseph Lee, released under GPL
 
 # Specific to Reset This PC window in Settings.
 

--- a/addon/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/addon/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -1,6 +1,6 @@
 # App module for Composable Shell (CShell) input panel
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2019 NV Access Limited, Joseph Lee
+# Copyright (C) 2017-2020 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/addon/appModules/winstore_app.py
+++ b/addon/appModules/winstore_app.py
@@ -1,6 +1,6 @@
 # Microsoft Store
 # Part of Windows 10 App Essentials collection
-# Copyright 2016-2019 Joseph Lee, released under GPL
+# Copyright 2016-2020 Joseph Lee, released under GPL
 
 # Enhancements to support Microsoft Store (formerly Windows Store).
 

--- a/addon/appModules/wwahost.py
+++ b/addon/appModules/wwahost.py
@@ -6,7 +6,7 @@
 """App module host for Windows 8.x WinRT apps hosted by wwahost.exe.
 """
 
-# Extended in 2019 to add additoinal properties and fixes.
+# Extended in 2019 to add additional properties and fixes.
 
 from nvdaBuiltin.appModules.wwahost import *
 import ctypes

--- a/addon/doc/fi/readme.md
+++ b/addon/doc/fi/readme.md
@@ -3,8 +3,9 @@
 * Tekijät: Joseph Lee, Derek Riemer sekä muut Windows 10:n käyttäjät
 * Lataa [vakaa versio][1]
 * Lataa [kehitysversio][2]
-* NVDA compatibility: 2019.3 and beyond
-* Download [older version][4] compatible with NVDA 2019.2.1 and earlier
+* Yhteensopivuus: NVDA 2019.3 ja uudemmat
+* Lataa [vanhempi versio,][4] joka on yhteensopiva NVDA 2019.2.1:n ja sitä
+  vanhempien kanssa
 
 Tämä lisäosa sisältää kokoelman sovellusmoduuleja Windows 10:n mukana
 tuleville sovelluksille sekä laajennuksia ja korjauksia tietyille
@@ -21,8 +22,8 @@ käytettävissä olevista ominaisuuksista kunkin sovelluksen kappaleesta):
 * Kartat
 * Microsoft Edge
 * Microsoft Store
-* Modern keyboard (emoji panel/dictation/hardware input suggestions/cloud
-  clipboard history/modern input method editors)
+* Moderni näppäimistö (emojipaneeli/sanelu/fyysisen näppäimistösyötteen
+  ehdotukset/pilvileikepöydän historia/modernin syöttömenetelmän editorit)
 * Ihmiset
 * Asetukset (järjestelmän asetukset, Windows+I)
 * Sää
@@ -30,9 +31,10 @@ käytettävissä olevista ominaisuuksista kunkin sovelluksen kappaleesta):
 
 Huomautuksia:
 
-* This add-on requires Windows 10 Version 1809 (build 17763) or later and
-  NVDA 2019.3 or later. For best results, use the add-on with latest Windows
-  10 stable release (build 18363) and latest stable version of NVDA.
+* Tämä lisäosa edellyttää Windows 10:n versiota 1809 (koontiversio 17763)
+  tai uudempaa ja NVDA 2019.3:a tai uudempaa. Käytä parhaan käyttökokemuksen
+  varmistamiseksi Windows 10:n viimeisintä vakaata versiota (koontiversio
+  18363) sekä uusinta vakaata NVDA:n versiota.
 * Jotkin lisäosan ominaisuudet ovat tai tulevat olemaan osa NVDA:ta.
 * Voidaan olettaa, että ominaisuudet, joita ei ole lueteltu alla, joko
   sisältyvät NVDA:han, eivät ole enää käytössä, koska lisäosa ei tue vanhoja
@@ -56,8 +58,9 @@ Katso luettelo lisäosan kaikkiin versioihin tehdyistä muutoksista
 * NVDA voi ilmoittaa ehdotusten määrän useimmissa tapauksissa hakua
   suoritettaessa. Tätä toimintoa hallitaan "Lue objektien sijaintitiedot"
   -asetuksella Objektien lukeminen -paneelista NVDA:n asetuksista.
-* NVDA will no longer announce "blank" when pressing up or down arrow to
-  open all apps views in Start menu. This is now part of NVDA 2019.3.
+* NVDA ei enää sano "tyhjä" painettaessa ylä- tai alanuolta kaikki
+  sovellukset -näkymän avaamiseksi Käynnistä-valikossa. Tämä sisältyy NVDA
+  2019.3:een.
 * NVDA puhuu nyt etsittäessä vähemmän hakutuloksia kahdesti
   Käynnistä-valikossa tai Resurssienhallinnassa versiossa 1909 (November
   2019 -päivitys) ja uudemmissa, mikä tekee lisäksi
@@ -74,14 +77,14 @@ Katso luettelo lisäosan kaikkiin versioihin tehdyistä muutoksista
   ilmoitukset tulevat muualta kuin aktiivisesta sovelluksesta.
 * On mahdollista seurata vain tiettyjä tapahtumia ja/tai tietyistä
   sovelluksista tulevia tapahtumia.
-* Tooltips from Edge and universal apps are recognized and will be
-  announced. This is now part of NVDA 2019.3.
+* Edgen ja universaalien sovellusten työkaluvihjeet tunnistetaan ja
+  puhutaan. Tämä sisältyy NVDA 2019.3:een.
 * NVDA ilmoittaa nykyisen työpöydän tunnisteen (esim. työpöytä 2) avattaessa
   ja suljettaessa virtuaalityöpöytiä tai siirryttäessä niiden välillä.
 * NVDA ei enää ilmoita Käynnistä-valikon kokoa  näytön resoluutiota tai
   suuntaa vaihdettaessa.
-* App name and version for various Microsoft Store apps are now shown
-  correctly. This is now part of NVDA 2019.3.
+* Useiden Microsoft Store -sovellusten nimi ja versio näytetään nyt
+  asianmukaisesti. Tämä sisältyy NVDA 2019.3:een.
 * Kun Käynnistä-valikon ruutuja tai Toimintokeskuksen pikatoimintoja
   järjestellään Alt+Vaihto+nuolinäppäimillä, NVDA puhuu raahattujen
   kohteiden tiedot tai raahatun kohteen uuden sijainnin.
@@ -116,8 +119,9 @@ Käynnistä-valikkoa.
 * NVDA on hiljaa puhuttaessa Cortanalle mikrofonin välityksellä.
 * NVDA puhuu nyt vahvistuksen muistutusta lisättäessä perinteisessä
   Cortanassa.
-* In Version 1909 (November 2019 Update) and later, modern search experience
-  in File Explorer powered by Windows Search user interface is supported.
+* Windows-haun käyttöliittymän voimalla toimivaa Resurssienhallinnan
+  modernia hakukokemusta tuetaan versiossa 1909 (marraskuun 2019 päivitys)
+  sekä 20H1:ssä (koontiversio 18945) ja uudemmissa.
 
 ## Palautekeskus
 
@@ -142,12 +146,12 @@ Käynnistä-valikkoa.
 
 Tämä viittaa perinteiseen EdgeHTML-pohjaiseen Microsoft Edgeen.
 
-* Text auto-complete will be tracked and announced in address omnibar. This
-  is now part of NVDA 2019.3.
-* NVDA will no longer play suggestion sound when pressing F11 to toggle full
-  screen. This is now part of NVDA 2019.3.
-* Removed suggestions sound playback for address omnibar. This is now part
-  of NVDA 2019.3.
+* Tekstin automaattista täydennystä seurataan ja sen tulokset puhutaan
+  osoitepalkissa. Tämä sisältyy NVDA 2019.3:een.
+* NVDA ei enää toista ehdotusääntä vaihdettaessa koko näytön tilaa F11:tä
+  painamalla. Tämä sisältyy NVDA 2019.3:een.
+* Ehdotusääntä ei enää toisteta osoitepalkissa. Tämä sisältyy NVDA
+  2019.3:een.
 
 ## Microsoft Store
 
@@ -158,24 +162,28 @@ Tämä viittaa perinteiseen EdgeHTML-pohjaiseen Microsoft Edgeen.
 
 ## Moderni näppäimistö
 
-This includes emoji panel, clipboard history, dictation, hardware input
-suggestions, and modern input method editors for certain languages. When
-viewing emojis, for best experience, enable Unicode Consortium setting from
-NvDA's speech settings and set symbol level to "some" or higher.
+Näitä ovat emojipaneeli, leikepöydän historia, sanelu, ehdotukset
+syötettäessä tekstiä fyysisellä näppäimistöllä sekä modernin
+syöttömenetelmän editorit tietyille kielille. Ota käyttöön emojeita
+tarkasteltaessa parhaan kokemuksen saamiseksi Unicode-konsortion datan
+asetus NVDA:n puheasetuksista ja aseta symbolitasoksi "jotain" tai
+korkeampi.
 
-* Support for Emoji input panel in Version 1709 (Fall Creators Update) and
-  later, including redesigned panel in Version 1809 (build 17661 and later)
-  and changes made in Version 1903 (build 18262 and later, including kaomoji
-  and symbols categories in build 18305). This is also applicable in Version
-  2004 (build 18963 and later) as the app has been renamed. All of these
-  changes are now part of NVDA 2019.3.
-* When opening clipboard history, NVDA will no longer announce "clipboard"
-  when there are items in the clipboard under some circumstances.
+* Tuki version 1709 (Fall Creators -päivitys) ja uudempien kelluvalle
+  emojinsyöttöpaneelille, mukaan lukien version 1809 (koontiversio 17661 ja
+  uudemmat) uudelleensuunniteltu paneeli sekä versioon 1903 (koontiversio
+  18262 ja uudemmat) tehdyt muutokset, mukaan lukien kaomoji sekä
+  koontiversion 18305 symbolikategoriat. Tämä koskee myös versiota 2004
+  (koontiversio 18963 ja uudemmat), sillä sovellus on nimetty
+  uudelleen. Nämä muutokset sisältyvät NVDA 2019.3:een.
+* NVDA ei enää sano leikepöydän historiaa avattaessa joissakin tilanteissa
+  "leikepöytä", kun leikepöydällä on kohteita.
 * Emojipaneelin avautuessa ei enää näytä siltä, että NVDA  ei tee mitään
   joissakin järjestelmissä, joissa on asennettuna Windows 10:n versio 1903
   (May 2019 -päivitys) tai uudempi.
-* Added support for modern Chinese, Japanese, and Korean (CJK) IME
-  candidates interface introduced in Version 2004 (build 18965 and later).
+* Lisätty tuki modernille kiinan, japanin ja korean (CJK) IME-ehdotusten
+  liittymälle, joka esiteltiin versiossa 2004 (koontiversio 18965 ja
+  uudemmat).
 
 ## Ihmiset
 
@@ -191,8 +199,9 @@ NvDA's speech settings and set symbol level to "some" or higher.
 * NVDA ei enää epäonnistu joidenkin yhdistelmäruutujen ja
   valintapainikkeiden selitteiden tunnistamisessa ja/tai arvomuutosten
   ilmoittamisessa.
-* Audio Volume progress bar beeps are no longer heard in Version 1803 and
-  later. This is now part of NVDA 2019.3.
+* Edistymispalkkien äänimerkkejä ei enää kuulu muutettaessa
+  äänenvoimakkuutta versiossa 1803 ja uudemmissa. Tämä sisältyy NVDA
+  2019.3:een.
 * NVDA ei tee enää mitään tai toista virheääniä, mikäli
   objektinavigointikomentoja käytetään tietyissä tilanteissa.
 * Windows Updaten muistutusvalintaikkuna tunnistetaan asianmukaisesti

--- a/addon/doc/pl/readme.md
+++ b/addon/doc/pl/readme.md
@@ -20,8 +20,9 @@ każdej aplikacji, aby dokładnie sprawdzić co jest wspierane):
 * Mapy
 * Microsoft Edge
 * Microsoft Store
-* Modern keyboard (emoji panel/dictation/hardware input suggestions/cloud
-  clipboard history/modern input method editors)
+* Klawiatura współczesna (panel emoji/dyktowanie/podpowiedzie wpisywania na
+  klawiaturze sprzętowej/historia schowka w chmurze/współczesne edytory
+  wprowadzania wschodnioazjatyckiego)
 * Osoby
 * Ustawienia (Ustawienia systemowe, Windows+I)
 * Pogoda.
@@ -29,9 +30,10 @@ każdej aplikacji, aby dokładnie sprawdzić co jest wspierane):
 
 Uwagi:
 
-* This add-on requires Windows 10 Version 1809 (build 17763) or later and
-  NVDA 2019.3 or later. For best results, use the add-on with latest Windows
-  10 stable release (build 18363) and latest stable version of NVDA.
+* Ten dodatek wymaga wersję systemu operacyjnego Windows 10 1809 (kompilacja
+  17763) lub nowsza i NVDA 2019.3 lub nowsza. Dla najlepszych wyników,
+  trzeba używać dodatku z ostatnią stabilną wersją operacyjnego systemu
+  Windows (kompilacja 18363) i najnowszą stabilną wersją NVDA.
 * Niektóre funkcję dodatku są, lub staną się częścią czytnika ekranu NVDA.
 * Dla wpisów nie podanych poniżej, można wnioskować, że zostały one
   wprowadzone do NVDA. Nie można ich już zastosować, ponieważ dodatek nie
@@ -55,8 +57,9 @@ Aby zobaczyć listę zmian pomiędzy kolejnymi wersjami, prosimy przeczytać
 * W większości przypadków, NVDA może ogłaszać liczbę sugestii
   wyszukiwania. Ta funkcja jest kontrolowana przez opcję "odczytuj położenie
   obiektu" dostępną w ustawieniach NVDA, w panelu "prezentacja obiektu".
-* NVDA will no longer announce "blank" when pressing up or down arrow to
-  open all apps views in Start menu. This is now part of NVDA 2019.3.
+* NVDA już nie będzie wymawiała "pusto" gdy jest naciśnięta strzałka w górę
+  lub w dół, aby otworzyć przegląd wszystkich aplikacji w meni start. Jest
+  to teraz częscia NVDA 2019.3.
 * Gdy jest uruchomione wyszukiwanie w wersji 1909 (aktualizacja listopadowa
   2019) i nowszych, podwójnie wymawianie wyników wyszukiwania jest mniej
   zauważalne, co idzie za tym, że to co jest wyświetlane na monitorze
@@ -73,15 +76,15 @@ Aby zobaczyć listę zmian pomiędzy kolejnymi wersjami, prosimy przeczytać
   aktywnej aplikacji.
 * Teraz jest możliwe śledzenie zdarzeń z określonych oraz specyficznych
   aplikacji.
-* Tooltips from Edge and universal apps are recognized and will be
-  announced. This is now part of NVDA 2019.3.
+* Dymki powiadomien z Edge i aplikacji uniwersalnych są rozpoznawani i są
+  wypowiadani. Jest to teraz częścią NVDA 2019.3.
 * Podczas otwierania, zamykając lub przełączając się między wirtualnymi
   pulpitami, NVDA będzie oznajmiała aktualny identyfikator (na przykład
   pulpit 2).
 * NVDA nie będzie wypowiadało wielkość tekstu w meni start, gdy zmienia się
   rozdzielczość ekranu lub orientacja ekranu.
-* App name and version for various Microsoft Store apps are now shown
-  correctly. This is now part of NVDA 2019.3.
+* Nazwa i wersja dla niektórych aplikacji z Microsoft store od teraz są
+  poprawnie wyświetlane. jest to teraz czescią NVDA 2019.3.
 * Przy ułożeniu kafelków meni start lub szybkich akcji w centrum akcji za
   pomocą Alt+Shift+strzałek, NVDA będzie wymawiała informację o
   upuszczonyche elementach lub o ich nowych pozycjach.
@@ -114,8 +117,9 @@ nowszych. Kortana klasyczna była częścią meni start.
 * NVDA będzie przyciszony, gdy mówisz do Cortany.
 * W Cortany klasycznej, NVDA będzie wypowiadała powiadomienia cortany kiedy
   jedne będzie ustawione.
-* In Version 1909 (November 2019 Update) and later, modern search experience
-  in File Explorer powered by Windows Search user interface is supported.
+* W wersji 1909 (aktualizacja dla listopada 2019) i nowszych, współczesne
+  wyszukiwanie używane przez interfejs wyszukiwania windows od teraz jest
+  wymawiane prawidłowo.
 
 ## Centrum opinii
 
@@ -140,12 +144,12 @@ nowszych. Kortana klasyczna była częścią meni start.
 
 Jest to odwołanie do klasycznego Microsoft edge.
 
-* Text auto-complete will be tracked and announced in address omnibar. This
-  is now part of NVDA 2019.3.
-* NVDA will no longer play suggestion sound when pressing F11 to toggle full
-  screen. This is now part of NVDA 2019.3.
-* Removed suggestions sound playback for address omnibar. This is now part
-  of NVDA 2019.3.
+* Tekst autouzupełniania w omnibarze będzie poprawnie śledzony i
+  wypowiadany. Jest to teraz częścią  NVDA 2019.3.
+* NVDA już nie będzie odtwarzałą dźwięk podpowiedzi gdy jest włączany tryb
+  pełnoekranowy za pomocą f11. Jest to od teraz częścia NVDA 2019.3.
+* Usunięto odtwarzanie dźwięku podpowiedzi dla omnibaru. Jest to od teraz
+  częścią NVDA 2019.3.
 
 ## Microsoft Store
 
@@ -156,24 +160,27 @@ Jest to odwołanie do klasycznego Microsoft edge.
 
 ## Klawiatura nowoczesna
 
-This includes emoji panel, clipboard history, dictation, hardware input
-suggestions, and modern input method editors for certain languages. When
-viewing emojis, for best experience, enable Unicode Consortium setting from
-NvDA's speech settings and set symbol level to "some" or higher.
+W to jest włączony panel emoji, historia schowka, dyktowanie, podpowiedzi
+dla wpisywania na klawiaturze sprzętowej, i współcześni edytorzy
+wprowadzania dla niektórych jezyków. Aby przeglądać emoji, dla najlepszego
+wrażenia, włącz dane konzorcjum unicode i ustaw poziom symboli na "niektóre"
+lub wyżej.
 
-* Support for Emoji input panel in Version 1709 (Fall Creators Update) and
-  later, including redesigned panel in Version 1809 (build 17661 and later)
-  and changes made in Version 1903 (build 18262 and later, including kaomoji
-  and symbols categories in build 18305). This is also applicable in Version
-  2004 (build 18963 and later) as the app has been renamed. All of these
-  changes are now part of NVDA 2019.3.
-* When opening clipboard history, NVDA will no longer announce "clipboard"
-  when there are items in the clipboard under some circumstances.
+* wsparcie dla Emoji panel wprowadzania w wersji 1709 (zimowa aktualizacja
+  dla twórców) i nowsze, włączając w to przeprojektowany panel w wersji 1809
+  (kompilacja 17661 i nowszy) i zmiany wprowadzone w wersji 1903 (kompilacja
+  18262 i nowsze, włączając w to kaomoji i kategorie symboli w kompilacji
+  18305). Jest to także zastosowane dla wersji 2004 (kompilacja 18963 i
+  nowsze) bo aplikacja zmieniła nazwę. Te wszystkie zmiany od teraz są
+  częscią NVDA 2019.3.
+* Gdy historia schowka jest wypowiadana, NVDA już nie będzie wymawiała
+  "schowek" w niektórych przypadkach, gdy istnieje treść.
 * Na niektórych komputerach na których jest uruchomiony Windows 10  1903
   (Aktualizacja z maju 2019), NVDA nie będzie wydawała efekt robienia nic
   gdy panel emoji się otwiera.
-* Added support for modern Chinese, Japanese, and Korean (CJK) IME
-  candidates interface introduced in Version 2004 (build 18965 and later).
+* Dodano wsparcie dla współczesnego interfejsu kandydatów dla chińskiego,
+  japońskiego, i koreańskiego (CJK) wprowadzonego w wersji 2004 (kompilacja
+  18965 i nowsze).
 
 ## Osoby
 
@@ -189,8 +196,8 @@ NvDA's speech settings and set symbol level to "some" or higher.
   automatycznie.
 * Dla niektórych list rozwijanych i przycisków opcji, NVDA będzie wykrywał
   nazwę oraz wypowiadał zmiany wartości. 
-* Audio Volume progress bar beeps are no longer heard in Version 1803 and
-  later. This is now part of NVDA 2019.3.
+* Paski postępu głośności już nie są słyszane w wersji 1803 i nowszej. jest
+  to od teraz częscią NVDA 2019.3.
 * W niektórych przypadkach, gdy używana jest nawigacja obiektowa, NVDA nie
   będzie się zachowywał  sposób nijaki, albo nie będzie odtwarzał dźwięku
   błedu.

--- a/addon/globalPlugins/wintenObjs/__init__.py
+++ b/addon/globalPlugins/wintenObjs/__init__.py
@@ -115,11 +115,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			if event not in UIAHandler.UIAEventIdsToNVDAEventNames:
 				UIAHandler.UIAEventIdsToNVDAEventNames[event] = name
 				UIAHandler.handler.clientObject.addAutomationEventHandler(event,UIAHandler.handler.rootElement,UIAHandler.TreeScope_Subtree,UIAHandler.handler.baseCacheRequest,UIAHandler.handler)
-				log.debug("W10: added event ID %s, assigned to %s"%(event, name))
+				log.debug(f"W10: added event ID {event}, assigned to {name}")
 		# Allow NVDA to recognize more dialogs, especially ones that are not advertising themselves as such.
 		for dialogClassName in UIAAdditionalDialogClassNames:
 			if dialogClassName not in UIAHandler.UIADialogClassNames:
-				log.debug("W10: adding class name %s to known dialog class names"%dialogClassName)
+				log.debug(f"W10: adding class name {dialogClassName} to known dialog class names")
 				UIAHandler.UIADialogClassNames.append(dialogClassName)
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
@@ -181,21 +181,21 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	# Record UIA property info about an object if told to do so.
 	def uiaDebugLogging(self, obj, event=None):
 		if self.recordLog(obj, event):
-			info = ["object: %s"%repr(obj)]
-			info.append("name: %s"%obj.name)
+			info = [f"object: {repr(obj)}"]
+			info.append(f"name: {obj.name}")
 			if not event:
 				event = "no event specified"
-			info.append("event: %s"%event)
-			info.append("app module: %s"%obj.appModule)
+			info.append(f"event: {event}")
+			info.append(f"app module: {obj.appModule}")
 			element = obj.UIAElement
-			info.append("automation Id: %s"%element.cachedAutomationID)
-			info.append("class name: %s"%element.cachedClassName)
+			info.append(f"automation Id: {element.cachedAutomationID}")
+			info.append(f"class name: {element.cachedClassName}")
 			if event == "controllerFor":
-				info.append("controller for count: %s"%len(obj.controllerFor))
+				info.append(f"controller for count: {len(obj.controllerFor)}")
 			elif event == "tooltipOpened":
-				info.append("framework Id: %s"%element.cachedFrameworkId)
+				info.append(f"framework Id: {element.cachedFrameworkId}")
 			elif event == "itemStatus":
-				info.append("item status: %s"%element.currentItemStatus)
+				info.append(f"item status: {element.currentItemStatus}")
 			if globalVars.appArgs.debugLogging:
 				log.debug(u"W10: UIA {debuginfo}".format(debuginfo = ", ".join(info)))
 			else:
@@ -209,7 +209,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			if globalVars.appArgs.debugLogging:
 				import tones
 				tones.beep(512, 50)
-				log.debug("W10: possible desktop name change from %s, app module: %s"%(obj,obj.appModule))
+				log.debug(f"W10: possible desktop name change from {obj}, app module: {obj.appModule}")
 			# CSRSS: Client/Server Runtime Subsystem (Windows subsystem process/desktop object)
 			if obj.appModule.appName == "csrss":
 				import wx
@@ -258,14 +258,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# Log which modern keyboard header is active.
 		# Although this can be done from modern keyboard app module, that module is destined for NVDA Core, hence do it here.
 		if obj.appModule.appName in ("windowsinternal_composableshell_experiences_textinput_inputapp", "textinputhost") and obj.firstChild is not None and globalVars.appArgs.debugLogging:
-			log.debug("W10: automation ID for currently opened modern keyboard feature is %s"%obj.firstChild.UIAElement.cachedAutomationID)
+			log.debug(f"W10: automation ID for currently opened modern keyboard feature is {obj.firstChild.UIAElement.cachedAutomationID}")
 		nextHandler()
 
 	def event_UIA_notification(self, obj, nextHandler, notificationKind=None, notificationProcessing=None, displayString=None, activityId=None):
 		# Introduced in Version 1709, to be treated as a notification event.
 		self.uiaDebugLogging(obj, "notification")
 		if isinstance(obj, UIA) and globalVars.appArgs.debugLogging:
-			log.debug("W10: UIA notification: sender: %s, notification kind: %s, notification processing: %s, display string: %s, activity ID: %s"%(obj.UIAElement,notificationKind,notificationProcessing,displayString,activityId))
+			log.debug(f"W10: UIA notification: sender: {obj.UIAElement}, notification kind: {notificationKind}, notification processing: {notificationProcessing}, display string: {displayString}, activity ID: {activityId}")
 			# Play a debug tone if and only if notifications come from somewhere other than the active app.
 			if obj.appModule != api.getFocusObject().appModule:
 				import tones

--- a/addon/globalPlugins/wintenObjs/__init__.py
+++ b/addon/globalPlugins/wintenObjs/__init__.py
@@ -75,21 +75,6 @@ class SearchField(SearchField):
 				queueHandler.queueFunction(queueHandler.eventQueue, ui.message, suggestionsMessage)
 
 
-# Some context menu items expose position info, which is quite anoying.
-class MenuItemNoPosInfo(UIA):
-
-	def _get_states(self):
-		# Borrowed from NVDA Core issue 5178 code (fixed provided by the same author).
-		states = super(MenuItemNoPosInfo, self).states
-		# Add proper state for submenus.
-		if self.UIAElement.cachedClassName == "MenuFlyoutSubItem":
-			states.add(controlTypes.STATE_HASPOPUP)
-		return states
-
-	def _get_positionInfo(self):
-		return {}
-
-
 # Various XAML headings (Settings app, for example) introduced in Version 1803.
 class XAMLHeading(UIA):
 
@@ -145,11 +130,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			# A dedicated version for Mail app's address/mention suggestions.
 			elif obj.UIAElement.cachedAutomationID == "RootFocusControl":
 				clsList.insert(0, UIAEditableTextWithSuggestions)
-				return
-			# Menu items should never expose position info (seen in various context menus such as in Edge).
-			# Also take care of recognizing submenus across apps.
-			elif obj.UIAElement.cachedClassName in ("MenuFlyoutItem", "MenuFlyoutSubItem"):
-				clsList.insert(0, MenuItemNoPosInfo)
 				return
 			# Recognize headings as reported by XAML (build 17134 and later).
 			elif obj._getUIACacheablePropertyValue(UIAHandler.UIA_HeadingLevelPropertyId) > UIAHandler.HeadingLevel_None:

--- a/addon/globalPlugins/wintenObjs/__init__.py
+++ b/addon/globalPlugins/wintenObjs/__init__.py
@@ -1,5 +1,5 @@
 # Windows 10 controls repository
-# Copyright 2015-2019 Joseph Lee, released under GPL.
+# Copyright 2015-2020 Joseph Lee, released under GPL.
 
 # Adds handlers for various UIA controls found in Windows 10.
 

--- a/addon/locale/sk/LC_MESSAGES/nvda.po
+++ b/addon/locale/sk/LC_MESSAGES/nvda.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: wintenApps 18.12\n"
 "Report-Msgid-Bugs-To: nvda-translations@freelists.org\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2019-04-14 15:09-0700\n"
-"Last-Translator: Ján Kulik <johny.kulik452@gmail.com>\n"
+"PO-Revision-Date: 2020-01-07 17:58+0100\n"
+"Last-Translator: Ondrej Rosík <ondrej.rosik@gmail.com>\n"
 "Language-Team: \n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.9\n"
+"X-Generator: Poedit 1.6.11\n"
 
 #. Translators: Dialog text shown when attempting to install the add-on on an unsupported version of Windows (minSupportedVersion is the minimum version required for this add-on).
 #, python-brace-format
@@ -29,23 +29,24 @@ msgstr ""
 
 #. Translators: title of the dialog shown when attempting to install the add-on on an old version of Windows.
 msgid "Old Windows version"
-msgstr "Stará verzia systému windows"
+msgstr "Staršia verzia systému windows"
 
 #. Customized because there is no easy way to obtain column position info for this object yet.
 #. Therefore report that this is not supported yet.
 msgid "Cannot move between rows"
-msgstr "Nemožno sa pohybovať medzi riadkami"
+msgstr "Nie je možné pohybovať sa medzi riadkami"
 
 #. Translators: Message presented when no more weather data is available for the current item.
 msgid "No more weather data for this item."
-msgstr "Žiadne dáta počasia pre Windows."
+msgstr "Nie sú dostupné ďalšie informácie o počasí pre túto lokalitu."
 
 #. Add-on summary, usually the user visible name of the addon.
 #. Translators: Summary for this add-on to be shown on installation and add-on information.
 msgid "Windows 10 App Essentials"
-msgstr "Windows 10 App Essentials"
+msgstr "Vylepšenia prístupnosti pre Windows 10"
 
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid "A collection of app modules for various Windows 10 apps"
-msgstr "Zbierka aplikácií modulov pre ďalšie aplikácie systému Windows 10."
+msgstr ""
+"Zbierka modulov, ktoré sprístupňujúf funkcie operačného systému Windows 10"

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""A collection of app modules for various Windows 10 apps"""),
 	# version
-	"addon_version" : "20.01",
+	"addon_version" : "20.02",
 	# Author(s)
 	"addon_author" : u"Joseph Lee <joseph.lee22590@gmail.com>, Derek Riemer <driemer.riemer@gmail.com> and others",
 	# URL for the add-on documentation support

--- a/readme.md
+++ b/readme.md
@@ -32,11 +32,9 @@ For a list of changes made between each add-on releases, refer to [changelogs fo
 ## General
 
 * NVDA will no longer play error tones or do nothing if this add-on becomes active from Windows 7, Windows 8.1, and unsupported releases of Windows 10.
-* Submenu items are properly recognized in various apps, including context menu for Start menu tiles.
 * In addition to dialogs recognized by NVDA, more dialogs are now recognized as proper dialogs and reported as such, including Insider Preview dialog (settings app).
 * NVDA can announce suggestion count when performing a search in majority of cases. This option is controlled by "Report object position information" in Object presentation panel found in NVDA settings.
 * When searching in Start menu or File Explorer in Version 1909 (November 2019 Update) and later, instances of NVDA announcing search results twice when reviewing results are less noticeable, which also makes braille output more consistent when reviewing items.
-* In certain context menus (such as in classic (EdgeHTML-based) Edge), position information (e.g. 1 of 2) is no longer announced.
 * The following UIA events are recognized: controller for, drag start, drag cancel, drag complete, drag target enter, drag target leave, drag target dropped, element selected, item status, live region change, notification, system alert, text change, tooltip opened, window opened. With NVDA set to run with debug logging enabled, these events will be tracked, and for UIA notification event, a debug tone will be heard if notifications come from somewhere other than the currently active app.
 * It is possible to tracke only specific events and/or events coming from specific apps.
 * When opening, closing, or switching between virtual desktops, NVDA will announce current desktop name (desktop 2, for example).

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ For a list of changes made between each add-on releases, refer to [changelogs fo
 
 ## Cortana
 
-Most items are no longer applicable on Version 1903 and later.
+Most items are no longer applicable on Version 1903 and later unless Cortana Conversations (Version 2004 and later) is in use.
 
 * Textual responses from Cortana are announced in most situations.
 * NVDA will be silent when talking to Cortana via voice.

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ For a list of changes made between each add-on releases, refer to [changelogs fo
 * In addition to dialogs recognized by NVDA, more dialogs are now recognized as proper dialogs and reported as such, including Insider Preview dialog (settings app).
 * NVDA can announce suggestion count when performing a search in majority of cases. This option is controlled by "Report object position information" in Object presentation panel found in NVDA settings.
 * When searching in Start menu or File Explorer in Version 1909 (November 2019 Update) and later, instances of NVDA announcing search results twice when reviewing results are less noticeable, which also makes braille output more consistent when reviewing items.
-* In certain context menus (such as in Edge), position information (e.g. 1 of 2) is no longer announced.
+* In certain context menus (such as in classic (EdgeHTML-based) Edge), position information (e.g. 1 of 2) is no longer announced.
 * The following UIA events are recognized: controller for, drag start, drag cancel, drag complete, drag target enter, drag target leave, drag target dropped, element selected, item status, live region change, notification, system alert, text change, tooltip opened, window opened. With NVDA set to run with debug logging enabled, these events will be tracked, and for UIA notification event, a debug tone will be heard if notifications come from somewhere other than the currently active app.
 * It is possible to tracke only specific events and/or events coming from specific apps.
 * When opening, closing, or switching between virtual desktops, NVDA will announce current desktop name (desktop 2, for example).

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The following app modules or support modules for some apps are included (see eac
 
 Notes:
 
-* This add-on requires Windows 10 Version 1903 (build 18362) or later and NVDA 2019.3 or later. For best results, use the add-on with latest Windows 10 stable release (build 18363) and latest stable version of NVDA.
+* This add-on requires Windows 10 Version 1903 (build 18362) or later. For best results, use the add-on with latest Windows 10 stable release (build 18363).
 * Some add-on features are or will be part of NVDA screen reader.
 * For entries not listed below, you can assume that features are part of NVDA, no longer applicable as the add-on does not support old Windows 10 releases, or changes were made to Windows 10 and apps that makes entries no longer applicable.
 


### PR DESCRIPTION
Windows 10 App Essentials 20.02.

Changelog:

* Initial support for Windows 10 Version 2004 (20H1 Update).
* Requires Windows 10 Version 1903 or later.
* Removed app modules for Feedback Hub, File Explorer, Microsoft Edge (EdgeHTML and emergency Chromium based), Search App in 20H1, Shell Experience Host, and Text Input Host/Modern keyboard in 20H1. For 20H1 apps, NVDA itself includes them.
* Removed submenu detection and position announcement workaround for various apps for consistency with recent Windows 10 and app changes.

Thanks.